### PR TITLE
CI changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install latest nightly
+      - name: Install rust toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable


### PR DESCRIPTION
fixes #27

A tacked on change is that ci now only runs on pull requests and on pushes to master. I'm making those changes here and now because all ci steps were running twice and my repeated pushes to this branch are what ultimately caused us to run out of CI minutes.

To re-summarize:
- Add rustfmt check to ci
- Only run CI for pull requests and for changes to master