### PR TITLE
Minimize docker image output size.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,5 @@ Dockerfile
 .git
 .github
 .gitignore
-scripts
 target
 tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,15 @@ WORKDIR /dock-testnet
 
 COPY --from=builder /dock-testnet/target/release/dock-testnet .
 
+# curl is required for uploading to keystore
+# note: `subkey insert` is a potential alternarve to curl
+RUN apt -y update \
+	&& apt install -y --no-install-recommends curl \
+	&& rm -rf /var/lib/apt/lists/*
+
+# might need these for uploads to keytore
+COPY scripts scripts
+
 # expose node ports
 EXPOSE 30333 9933 9944
 


### PR DESCRIPTION
Changing from `ubuntu:bionic` to `debian:stretch-slim` saves about 9MB.
Removing curl shaves another 30MB off the image.

After both optimizations the image is around 90MB total.

These changes are in preparation for pushing to dockerhub.