### PR TITLE
CI: Automatically build rustdocs on master and post to gh-pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,30 @@
+name: Rust
+
+on:
+  push:
+    branches:
+      - master
+      - build-for-gh-pages
+
+jobs:
+  update-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install latest nightly
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+      - name: Install WASM
+        run: rustup target add wasm32-unknown-unknown --toolchain nightly
+      - name: Build Docs
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+      - name: Push To gh-pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./target/doc
+          force_orphan: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - build-for-gh-pages
 
 jobs:
   update-docs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,8 @@ jobs:
           override: true
       - name: Install WASM
         run: rustup target add wasm32-unknown-unknown --toolchain nightly
+      - name: Ensure docs are buildable
+        run: cargo doc
       - name: Run tests
         run: cargo test --all
 


### PR DESCRIPTION
See https://docknetwork.github.io/dock-substrate/dock_testnet_runtime for build output.