### PR TITLE
Modify public interface to be more relevant to the user.

### DIFF
--- a/runtime/src/did.rs
+++ b/runtime/src/did.rs
@@ -12,7 +12,7 @@ use sp_std::fmt;
 use system::ensure_signed;
 
 /// Size of the Dock DID in bytes
-pub const DID_BYTE_SIZE: usize = 32;
+const DID_BYTE_SIZE: usize = 32;
 /// The type of the Dock DID
 pub type Did = [u8; DID_BYTE_SIZE];
 
@@ -127,7 +127,7 @@ pub enum DidSignature {
 
 impl DidSignature {
     /// Try to get reference to the bytes if its a Sr25519 signature. Return error if its not.
-    pub fn as_sr25519_sig_bytes(&self) -> Result<&[u8], ()> {
+    fn as_sr25519_sig_bytes(&self) -> Result<&[u8], ()> {
         match self {
             DidSignature::Sr25519(bytes) => Ok(bytes.as_bytes()),
             _ => Err(()),
@@ -135,7 +135,7 @@ impl DidSignature {
     }
 
     /// Try to get reference to the bytes if its a Ed25519 signature. Return error if its not.
-    pub fn as_ed25519_sig_bytes(&self) -> Result<&[u8], ()> {
+    fn as_ed25519_sig_bytes(&self) -> Result<&[u8], ()> {
         match self {
             DidSignature::Ed25519(bytes) => Ok(bytes.as_bytes()),
             _ => Err(()),
@@ -143,7 +143,7 @@ impl DidSignature {
     }
 
     /// Try to get reference to the bytes if its a Secp256k1 signature. Return error if its not.
-    pub fn as_secp256k1_sig_bytes(&self) -> Result<&[u8], ()> {
+    fn as_secp256k1_sig_bytes(&self) -> Result<&[u8], ()> {
         match self {
             DidSignature::Secp256k1(bytes) => Ok(bytes.as_bytes()),
             _ => Err(()),

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -1,13 +1,18 @@
 use dock_testnet_runtime::{
-    AccountId, AuraConfig, BalancesConfig, GenesisConfig, GrandpaConfig, IndicesConfig, Signature,
-    SudoConfig, SystemConfig, WASM_BINARY,
+    AuraConfig, BalancesConfig, GenesisConfig, GrandpaConfig, IndicesConfig, SudoConfig,
+    SystemConfig, WASM_BINARY,
 };
 use grandpa_primitives::AuthorityId as GrandpaId;
 use sc_service;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_core::crypto::Ss58Codec;
 use sp_core::{sr25519, Pair, Public};
-use sp_runtime::traits::{IdentifyAccount, Verify};
+use sp_runtime::{
+    traits::{IdentifyAccount, Verify},
+    MultiSignature,
+};
+
+type AccountId = <<MultiSignature as Verify>::Signer as IdentifyAccount>::AccountId;
 
 // Note this is the URL for the telemetry server
 //const STAGING_TELEMETRY_URL: &str = "wss://telemetry.polkadot.io/submit/";
@@ -36,10 +41,10 @@ pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Pu
         .public()
 }
 
-type AccountPublic = <Signature as Verify>::Signer;
+type AccountPublic = <MultiSignature as Verify>::Signer;
 
 /// Helper function to generate an account ID from seed
-pub fn get_account_id_from_seed<TPublic: Public>(seed: &str) -> AccountId
+fn get_account_id_from_seed<TPublic: Public>(seed: &str) -> AccountId
 where
     AccountPublic: From<<TPublic::Pair as Pair>::Public>,
 {
@@ -47,7 +52,7 @@ where
 }
 
 /// Helper function to generate an authority key for Aura
-pub fn get_authority_keys_from_seed(s: &str) -> (AuraId, GrandpaId) {
+fn get_authority_keys_from_seed(s: &str) -> (AuraId, GrandpaId) {
     (get_from_seed::<AuraId>(s), get_from_seed::<GrandpaId>(s))
 }
 
@@ -66,7 +71,7 @@ where
 
 impl Alternative {
     /// Get an actual chain config from one of the alternatives.
-    pub(crate) fn load(self) -> Result<ChainSpec, String> {
+    pub fn load(self) -> Result<ChainSpec, String> {
         Ok(match self {
             Alternative::Development => ChainSpec::from_genesis(
                 "Development",

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ mod chain_spec;
 mod service;
 mod cli;
 
-pub use sc_cli::{error, IntoExit, VersionInfo};
+use sc_cli::VersionInfo;
 
 fn main() -> Result<(), cli::error::Error> {
     let version = VersionInfo {

--- a/src/service.rs
+++ b/src/service.rs
@@ -5,7 +5,6 @@ use grandpa::{self, FinalityProofProvider as GrandpaFinalityProofProvider};
 use sc_basic_authority;
 use sc_client::LongestChain;
 use sc_executor::native_executor_instance;
-pub use sc_executor::NativeExecutor;
 use sc_network::construct_simple_protocol;
 use sc_service::{error::Error as ServiceError, AbstractService, Configuration, ServiceBuilder};
 use sp_consensus_aura::sr25519::AuthorityPair as AuraPair;
@@ -15,7 +14,7 @@ use std::time::Duration;
 
 // Our native executor instance.
 native_executor_instance!(
-	pub Executor,
+	pub(crate) Executor,
 	dock_testnet_runtime::api::dispatch,
 	dock_testnet_runtime::native_version,
 );


### PR DESCRIPTION
Make necessary runtime items pub.
Remove most irrelevant items (like construct_runtime) from public interface.