### PR TITLE
working invocation of cargo doc

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,9 +18,7 @@ jobs:
       - name: Install WASM
         run: rustup target add wasm32-unknown-unknown --toolchain nightly
       - name: Build Docs
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc --no-deps
+        run: cargo doc --no-deps
       - name: Push To gh-pages
         uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
The previous call to the `actions-rs/cargo` was invalid. https://github.com/docknetwork/dock-substrate/runs/710915961?check_suite_focus=true

This pr fixes the call.

CI will fail because the current version of rust nightly is broken.