### PR TITLE
derive serde and expose fields of interface types for rust rpc client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,6 +767,7 @@ dependencies = [
  "parity-scale-codec",
  "rand 0.7.3",
  "serde",
+ "serde-big-array",
  "sp-api",
  "sp-block-builder",
  "sp-consensus-aura",
@@ -4564,6 +4565,16 @@ version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36df6ac6412072f67cf767ebbde4133a5b2e88e76dc6187fa7104cd16f783399"
 dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde-big-array"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52309f7932ab258e58bcf73cc89037e307ffef3bcfb7ce7a246580c26f81dc55"
+dependencies = [
+ "serde",
  "serde_derive",
 ]
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -49,6 +49,10 @@ features = ['derive']
 optional = true
 version = '1.0.101'
 
+[dependencies.serde-big-array]
+optional = true
+version = "0.3.0"
+
 [dependencies.sp-api]
 git = 'https://github.com/paritytech/substrate.git'
 default-features = false
@@ -166,6 +170,7 @@ std = [
     'grandpa/std',
     'randomness-collective-flip/std',
     'serde',
+    'serde-big-array',
     'sp-api/std',
     'sp-block-builder/std',
     'sp-consensus-aura/std',

--- a/runtime/src/blob.rs
+++ b/runtime/src/blob.rs
@@ -17,10 +17,11 @@ pub type BlobId = [u8; ID_BYTE_SIZE];
 
 /// When a new blob is being registered, the following object is sent.
 #[derive(Encode, Decode, Clone, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Blob {
-    id: BlobId,
-    blob: Vec<u8>,
-    author: did::Did,
+    pub id: BlobId,
+    pub blob: Vec<u8>,
+    pub author: did::Did,
 }
 
 pub trait Trait: system::Trait + did::Trait {

--- a/runtime/src/did.rs
+++ b/runtime/src/did.rs
@@ -44,6 +44,7 @@ decl_error! {
 // XXX: This could have been a tuple struct. Keeping it a normal struct for Substrate UI
 /// A wrapper over 32-byte array
 #[derive(Encode, Decode, Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bytes32 {
     pub value: [u8; 32],
 }
@@ -54,6 +55,12 @@ impl Bytes32 {
     }
 }
 
+#[cfg(feature = "serde")]
+serde_big_array::big_array! {
+    BigArray;
+    33, 64, 65
+}
+
 // XXX: These could have been a tuple structs. Keeping them normal struct for Substrate UI
 /// Creates a struct named `$name` which contains only 1 element which is a bytearray, useful when
 /// wrapping arrays of size > 32. `$size` is the size of the underlying bytearray. Implements the `Default`,
@@ -62,7 +69,9 @@ macro_rules! struct_over_byte_array {
     ( $name:ident, $size:tt ) => {
         /// A wrapper over a byte array
         #[derive(Encode, Decode, Clone)]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         pub struct $name {
+            #[cfg_attr(feature = "serde", serde(with = "BigArray"))]
             pub value: [u8; $size],
         }
 
@@ -105,6 +114,7 @@ struct_over_byte_array!(Bytes65, 65);
 /// An abstraction for a public key. Abstracts the type and value of the public key where the value is a
 /// byte array
 #[derive(Encode, Decode, Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum PublicKey {
     /// Public key for Sr25519 is 32 bytes
     Sr25519(Bytes32),
@@ -116,6 +126,7 @@ pub enum PublicKey {
 
 /// An abstraction for a signature.
 #[derive(Encode, Decode, Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum DidSignature {
     /// Signature for Sr25519 is 64 bytes
     Sr25519(Bytes64),
@@ -176,6 +187,7 @@ pub struct Bytes32(pub [u8;32]);*/
 /// `controller` is the controller DID and its value might be same as `did`.
 /// `public_key` is the public key and it is accepted and stored as raw bytes.
 #[derive(Encode, Decode, Clone, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KeyDetail {
     controller: Did,
     public_key: PublicKey,
@@ -204,11 +216,12 @@ impl KeyDetail {
 /// successful extrinsic and the chain requiring the extrinsic's nonce to be higher than current.
 /// This is little more involved as it involves a ">" check
 #[derive(Encode, Decode, Clone, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KeyUpdate {
-    did: Did,
-    public_key: PublicKey,
-    controller: Option<Did>,
-    last_modified_in_block: BlockNumber,
+    pub did: Did,
+    pub public_key: PublicKey,
+    pub controller: Option<Did>,
+    pub last_modified_in_block: BlockNumber,
 }
 
 impl KeyUpdate {
@@ -233,9 +246,10 @@ impl KeyUpdate {
 /// `did` is the DID which is being removed.
 /// `last_modified_in_block` is the block number when this DID was last modified. The last modified time is present to prevent replay attack.
 #[derive(Encode, Decode, Clone, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DidRemoval {
-    did: Did,
-    last_modified_in_block: BlockNumber,
+    pub did: Did,
+    pub last_modified_in_block: BlockNumber,
 }
 
 impl DidRemoval {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -75,6 +75,7 @@ type Hash = sp_core::H256;
 /// not self describing.
 /// Never change the order of variants in this enum
 #[derive(Encode, Decode)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum StateChange {
     KeyUpdate(did::KeyUpdate),
     DIDRemoval(did::DidRemoval),

--- a/runtime/src/revoke.rs
+++ b/runtime/src/revoke.rs
@@ -16,6 +16,7 @@ pub type PAuth = BTreeMap<Did, DidSignature>;
 
 /// Authorization logic for a registry.
 #[derive(PartialEq, Eq, Encode, Decode, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Policy {
     /// Set of dids allowed to modify a registry.
     OneOf(BTreeSet<Did>),
@@ -33,6 +34,7 @@ impl Policy {
 
 /// Metadata about a revocation scope.
 #[derive(PartialEq, Eq, Encode, Decode, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Registry {
     /// Who is allowed to update this registry.
     pub policy: Policy,
@@ -45,6 +47,7 @@ pub struct Registry {
 /// Creation of revocations is idempotent; creating a revocation that already exists is allowed,
 /// but has no effect.
 #[derive(PartialEq, Eq, Encode, Decode, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Revoke {
     /// The registry on which to operate
     pub registry_id: RegistryId,
@@ -58,6 +61,7 @@ pub struct Revoke {
 /// Removal of revocations is idempotent; removing a revocation that doesn't exists is allowed,
 /// but has no effect.
 #[derive(PartialEq, Eq, Encode, Decode, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UnRevoke {
     /// The registry on which to operate
     pub registry_id: RegistryId,
@@ -70,6 +74,7 @@ pub struct UnRevoke {
 /// Command to remove an entire registy. Removes all revocations in the registry as well as
 /// registry metadata.
 #[derive(PartialEq, Eq, Encode, Decode, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RemoveRegistry {
     /// The registry on which to operate
     pub registry_id: RegistryId,


### PR DESCRIPTION
Substrate auto-generates typed rust rpc client for our runtime. This pr makes it so that users can take full advantage of said client. Previously some fields, like Blob::blob were inaccessible because they weren't marked as pub, so if a user did manage to pull a blob off the chain, they wouldn't be able to read the contents. In fact, Blob was previously not constructible for external crates except through the `Decode` implantation.

This pr makes it possible for users to create and read our interface types. It also adds optional serde implementations as the types are [data structures](https://rust-lang.github.io/api-guidelines/interoperability.html?highlight=serde#data-structures-implement-serdes-serialize-deserialize-c-serde).