### PR TITLE
Emission rewards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3235,6 +3235,7 @@ dependencies = [
  "pallet-session",
  "parity-scale-codec",
  "serde",
+ "sp-arithmetic",
  "sp-core",
  "sp-io",
  "sp-runtime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3235,7 +3235,6 @@ dependencies = [
  "pallet-session",
  "parity-scale-codec",
  "serde",
- "sp-arithmetic",
  "sp-core",
  "sp-io",
  "sp-runtime",

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -249,7 +249,7 @@ fn testnet_genesis(
                 .collect::<Vec<_>>(),
         }),
         poa: Some(PoAModuleConfig {
-            min_epoch_length: 5,
+            min_epoch_length: 16,
             max_active_validators: 4,
             active_validators: initial_authorities
                 .iter()
@@ -259,6 +259,7 @@ fn testnet_genesis(
             max_emm_validator_epoch,
             treasury_reward_pc: 60,
             validator_reward_lock_pc: 50,
+            // TODO: This will be false on mainnet launch as there won't be any tokens.
             emission_status: true,
         }),
         balances: Some(BalancesConfig {

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -203,10 +203,6 @@ pub fn local_poa_testnet_config() -> ChainSpec {
                     get_account_id_from_seed::<sr25519::Public>("Ferdie"),
                     get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
                     get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
-                    // get_account_id_from_seed::<sr25519::Public>("Charlie//stash"),
-                    // get_account_id_from_seed::<sr25519::Public>("Dave//stash"),
-                    // get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
-                    // get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
                 ],
             )
         },

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -249,6 +249,8 @@ fn testnet_genesis(
                 .collect::<Vec<_>>(),
         }),
         poa: Some(PoAModuleConfig {
+            min_epoch_length: 5,
+            max_active_validators: 4,
             active_validators: initial_authorities
                 .iter()
                 .map(|x| x.0.clone())

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -203,10 +203,10 @@ pub fn local_poa_testnet_config() -> ChainSpec {
                     get_account_id_from_seed::<sr25519::Public>("Ferdie"),
                     get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
                     get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
-                    get_account_id_from_seed::<sr25519::Public>("Charlie//stash"),
-                    get_account_id_from_seed::<sr25519::Public>("Dave//stash"),
-                    get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
-                    get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
+                    // get_account_id_from_seed::<sr25519::Public>("Charlie//stash"),
+                    // get_account_id_from_seed::<sr25519::Public>("Dave//stash"),
+                    // get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
+                    // get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
                 ],
             )
         },
@@ -223,6 +223,18 @@ fn testnet_genesis(
     root_key: AccountId,
     endowed_accounts: Vec<AccountId>,
 ) -> GenesisConfig {
+    // 1 token is 25000000 gas
+    let token_to_gas: u128 = 25_000_000;
+    // 200M tokens
+    let emission_supply: u128 = token_to_gas * 200_000_000;
+    // TODO: This needs to be tweaked once we know all exchanges
+    // 100M tokens
+    let per_member_endowment: u128 = token_to_gas * 100_000_000;
+
+    // Max emission per validator in an epoch
+    // 30K tokens
+    let max_emm_validator_epoch: u128 = token_to_gas * 30_000;
+
     GenesisConfig {
         system: Some(SystemConfig {
             code: WASM_BINARY.to_vec(),
@@ -245,12 +257,16 @@ fn testnet_genesis(
                 .iter()
                 .map(|x| x.0.clone())
                 .collect::<Vec<_>>(),
+            emission_supply,
+            max_emm_validator_epoch,
+            treasury_reward_pc: 60,
+            validator_reward_lock_pc: 50,
         }),
         balances: Some(BalancesConfig {
             balances: endowed_accounts
                 .iter()
                 .cloned()
-                .map(|k| (k, 1 << 60))
+                .map(|k| (k, per_member_endowment))
                 .collect(),
         }),
         sudo: Some(SudoConfig { key: root_key }),

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -257,6 +257,7 @@ fn testnet_genesis(
             max_emm_validator_epoch,
             treasury_reward_pc: 60,
             validator_reward_lock_pc: 50,
+            emission_status: true,
         }),
         balances: Some(BalancesConfig {
             balances: endowed_accounts

--- a/pallets/poa/Cargo.toml
+++ b/pallets/poa/Cargo.toml
@@ -69,6 +69,12 @@ default-features = false
 tag = 'v2.0.0-rc4'
 version = '2.0.0-rc4'
 
+[dependencies.sp-arithmetic]
+git = 'https://github.com/paritytech/substrate.git'
+default-features = false
+tag = 'v2.0.0-rc4'
+version = '2.0.0-rc4'
+
 [dev-dependencies.balances]
 git = 'https://github.com/paritytech/substrate.git'
 default-features = false
@@ -86,6 +92,7 @@ std = [
     'serde',
     'pallet-session/std',
     'pallet-authorship/std',
+    'sp-arithmetic/std',
 ]
 
 test = ['std', 'balances/std']

--- a/pallets/poa/Cargo.toml
+++ b/pallets/poa/Cargo.toml
@@ -69,12 +69,6 @@ default-features = false
 tag = 'v2.0.0-rc4'
 version = '2.0.0-rc4'
 
-[dependencies.sp-arithmetic]
-git = 'https://github.com/paritytech/substrate.git'
-default-features = false
-tag = 'v2.0.0-rc4'
-version = '2.0.0-rc4'
-
 [dev-dependencies.balances]
 git = 'https://github.com/paritytech/substrate.git'
 default-features = false
@@ -92,7 +86,6 @@ std = [
     'serde',
     'pallet-session/std',
     'pallet-authorship/std',
-    'sp-arithmetic/std',
 ]
 
 test = ['std', 'balances/std']

--- a/pallets/poa/src/lib.rs
+++ b/pallets/poa/src/lib.rs
@@ -214,7 +214,9 @@ decl_event!(
         // Validator removed.
         ValidatorRemoved(AccountId),
 
-        EpochBegins(SlotNo),
+        EpochBegins(EpochNo, SlotNo),
+
+        EpochEnds(EpochNo, SlotNo),
     }
 );
 
@@ -1074,6 +1076,8 @@ impl<T: Trait> Module<T> {
         Self::mint_emission_rewards_if_needed(current_epoch_no, ending_slot, &mut epoch_detail);
 
         Epochs::insert(current_epoch_no, epoch_detail);
+
+        Self::deposit_event(RawEvent::EpochBegins(current_epoch_no, ending_slot));
     }
 
     /// Set last slot for previous epoch, starting slot of current epoch and active validator count
@@ -1097,6 +1101,7 @@ impl<T: Trait> Module<T> {
                 Self::epoch_ends_at(),
             ),
         );
+        Self::deposit_event(RawEvent::EpochBegins(current_epoch_no, current_slot_no));
     }
 
     /// The validator set needs to update, either due to swap or epoch end.

--- a/pallets/poa/src/lib.rs
+++ b/pallets/poa/src/lib.rs
@@ -955,7 +955,13 @@ impl<T: Trait> Module<T> {
     }
 
     /// Calculate validator and treasury rewards for epoch with non-zero rewards and reward each
-    /// validator
+    /// validator. During each epoch, the network will offer at most `p` tokens to each validator,
+    /// thus the network (with `n` validators) will offer at max `p*n` Dock tokens in total to all validators.
+    /// If a validator is fully available, i.e. it produces all the blocks that it can, it will get `p` tokens
+    /// in the epoch. However, if the validator is unavailable for some time (the node crashed, the network was
+    /// down or some other reason), they get proportionately less rewards. The max rewards `p` will decrease in
+    /// proportion if epoch is shorter than minimum epoch length. Once the total rewards for validators
+    /// are calculated, an extra `t` percent of that is emitted for the treasury.
     fn mint_rewards_for_non_empty_epoch(
         epoch_detail: &mut EpochDetail,
         current_epoch_no: EpochNo,

--- a/pallets/poa/src/lib.rs
+++ b/pallets/poa/src/lib.rs
@@ -870,12 +870,15 @@ impl<T: Trait> Module<T> {
 
     /// Credit locked balance to validator's account as reserved balance
     fn credit_locked_emission_rewards_to_validator(validator: &T::AccountId, locked: u128) {
-        let locked_bal = locked.saturated_into();
-        // Deposit locked balance
-        T::Currency::deposit_creating(validator, locked_bal);
-        // Reserve the balance.
-        // The following unwrap will never throw error as the balance to reserve was just transferred.
-        T::Currency::reserve(validator, locked_bal).unwrap();
+        // Only proceed if locked balance > 0 as we don't care about positive imbalances (0 or otherwise)
+        if locked > 0 {
+            let locked_bal = locked.saturated_into();
+            // Deposit locked balance
+            T::Currency::deposit_creating(validator, locked_bal);
+            // Reserve the balance.
+            // The following unwrap will never throw error as the balance to reserve was just transferred.
+            T::Currency::reserve(validator, locked_bal).unwrap();
+        }
     }
 
     /// Credit unlocked and locked balance to validator's account

--- a/pallets/poa/src/lib.rs
+++ b/pallets/poa/src/lib.rs
@@ -58,9 +58,12 @@ pub struct EpochDetail {
 pub struct ValidatorStatsPerEpoch {
     /// Count of blocks authored by the validator in the epoch
     pub block_count: EpochLen,
-    /// Amount of locked rewards earned by the validator in the epoch
+    /// Amount of locked rewards earned by the validator in the epoch. This reward is added to the
+    /// reserved balance (by calling `Balances::reserve`) of the validator. When unlocking (during PoS),
+    /// we move this reserved balance to free balance (by calling `Balances::unreserve` and pass amount)
+    /// for each epoch since beginning, thus giving us the gradual release functionality.
     pub locked_reward: Option<u128>,
-    /// Amount of unlocked rewards earned by the validator in the epoch
+    /// Amount of unlocked rewards earned by the validator in the epoch.
     pub unlocked_reward: Option<u128>,
 }
 

--- a/pallets/poa/src/lib.rs
+++ b/pallets/poa/src/lib.rs
@@ -611,6 +611,27 @@ impl<T: Trait> pallet_session::ShouldEndSession<T::BlockNumber> for Module<T> {
         let swap = <HotSwap<T>>::take();
 
         if (current_slot_no > epoch_ends_at) || swap.is_some() {
+            /*let (active_validator_set_changed, active_validator_count) =
+                match Self::swap_if_needed(swap) {
+                    Some(count) => {
+                        // Swap occurred, check if the swap coincided with an epoch end
+                        if current_slot_no > epoch_ends_at {
+                            let (changed, new_count) = Self::update_active_validators_if_needed();
+                            // There is a chance that `update_active_validators_if_needed` undoes the swap and in that case
+                            // rotate_session can be avoided.
+                            if changed {
+                                // The epoch end changed the active validator set and count
+                                (changed, new_count)
+                            } else {
+                                (true, count)
+                            }
+                        } else {
+                            // Epoch did not end but swap did happen
+                            (true, count)
+                        }
+                    },
+                    None => Self::update_active_validators_if_needed(),
+                };*/
             let (active_validator_set_changed, active_validator_count) = Self::update_validator_set(current_slot_no, epoch_ends_at, swap);
 
             if active_validator_set_changed {

--- a/pallets/poa/src/lib.rs
+++ b/pallets/poa/src/lib.rs
@@ -1221,7 +1221,7 @@ impl<T: Trait> pallet_session::SessionManager<T::AccountId> for Module<T> {
 
         let validators = Self::active_validators();
         if validators.len() == 0 {
-            return None
+            return None;
         }
         if session_idx < 2 {
             // `session_idx` 0 and 1 are called on genesis

--- a/pallets/poa/src/tests.rs
+++ b/pallets/poa/src/tests.rs
@@ -1647,3 +1647,12 @@ fn config_set_by_master() {
         assert_eq!(PoAModule::treasury_reward_pc(), 0);
     });
 }
+
+#[test]
+fn expected_treasury_account_id() {
+    use sp_runtime::traits::AccountIdConversion;
+    assert_eq!(
+        AccountIdConversion::<[u8; 32]>::into_account(&TREASURY_ID),
+        *b"modlTreasury\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
+    );
+}

--- a/pallets/poa/src/tests.rs
+++ b/pallets/poa/src/tests.rs
@@ -156,7 +156,7 @@ fn new_test_ext() -> sp_io::TestExternalities {
 fn current_epoch_end() {
     new_test_ext().execute_with(|| {
         // Minimum epoch length is 25
-        for (starting_slot, validator_count, ending_slot) in vec![
+        for (starting_slot, validator_count, ending_slot) in &[
             (1, 2, 26),
             (1, 3, 27),
             (1, 4, 28),
@@ -200,9 +200,10 @@ fn current_epoch_end() {
             (81, 4, 108),
             (23, 4, 50),
             (39, 4, 66),
-        ] {
-            let epoch_end = PoAModule::set_next_epoch_end(starting_slot, validator_count);
-            assert_eq!(epoch_end, ending_slot);
+        ][..]
+        {
+            let epoch_end = PoAModule::set_next_epoch_end(*starting_slot, *validator_count);
+            assert_eq!(epoch_end, *ending_slot);
             assert_eq!(PoAModule::epoch_ends_at(), epoch_end);
         }
     });
@@ -214,7 +215,7 @@ fn short_circuit_epoch() {
         // Minimum epoch length is 25
         let current_epoch_no = 1;
         Epoch::put(current_epoch_no);
-        for (validator_count, starting_slot, current_slot_no, expected_epoch_end) in vec![
+        for (validator_count, starting_slot, current_slot_no, expected_epoch_end) in &[
             (2, 1, 10, 10),
             (2, 1, 9, 10),
             (2, 1, 11, 12),
@@ -238,10 +239,10 @@ fn short_circuit_epoch() {
             Epochs::insert(
                 current_epoch_no,
                 // expected ending slot has a dummy value as its not being tested in here
-                EpochDetail::new(validator_count, starting_slot, 0),
+                EpochDetail::new(*validator_count, *starting_slot, 0),
             );
-            let epoch_end = PoAModule::update_current_epoch_end_on_short_circuit(current_slot_no);
-            assert_eq!(epoch_end, expected_epoch_end);
+            let epoch_end = PoAModule::update_current_epoch_end_on_short_circuit(*current_slot_no);
+            assert_eq!(epoch_end, *expected_epoch_end);
             assert_eq!(PoAModule::epoch_ends_at(), epoch_end);
         }
     });
@@ -262,16 +263,16 @@ fn add_validator_basic() {
 
         // Enqueue validators
         let mut queued_validators = vec![];
-        for id in vec![val_id1, val_id2, val_id3, val_id4, val_id5] {
+        for id in &[val_id1, val_id2, val_id3, val_id4, val_id5] {
             // Adding a validator should work
-            assert_ok!(PoAModule::add_validator_(id, false));
+            assert_ok!(PoAModule::add_validator_(*id, false));
             // Cannot add the same validator when validator is already active validator
             assert_err!(
-                PoAModule::add_validator_(id, false),
+                PoAModule::add_validator_(*id, false),
                 Error::<TestRuntime>::AlreadyQueuedForAddition
             );
 
-            queued_validators.push(id.clone());
+            queued_validators.push(*id);
             // Validators should be added to the queue
             assert_eq!(PoAModule::validators_to_add(), queued_validators);
             // Active validator set should not change
@@ -326,8 +327,8 @@ fn remove_validator_basic() {
         let val_id6 = 6;
 
         // Add validators in queue and then to active validator set
-        for id in vec![val_id1, val_id2, val_id3, val_id4, val_id5] {
-            PoAModule::add_validator_(id, false).unwrap();
+        for id in &[val_id1, val_id2, val_id3, val_id4, val_id5] {
+            PoAModule::add_validator_(*id, false).unwrap();
         }
         PoAModule::update_active_validators_if_needed();
 
@@ -395,8 +396,8 @@ fn add_remove_validator() {
         let val_id6 = 6;
 
         // Add same validator, `val_id3`, for both addition and removal
-        for id in vec![val_id1, val_id2, val_id3, val_id4] {
-            PoAModule::add_validator_(id, false).unwrap();
+        for id in &[val_id1, val_id2, val_id3, val_id4] {
+            PoAModule::add_validator_(*id, false).unwrap();
         }
         PoAModule::remove_validator_(val_id3, false).unwrap();
 
@@ -445,8 +446,8 @@ fn swap_validator() {
         let val_id5 = 5;
         let val_id6 = 6;
 
-        for id in vec![val_id1, val_id2, val_id3, val_id4] {
-            PoAModule::add_validator_(id, false).unwrap();
+        for id in &[val_id1, val_id2, val_id3, val_id4] {
+            PoAModule::add_validator_(*id, false).unwrap();
         }
         PoAModule::update_active_validators_if_needed();
 
@@ -492,8 +493,8 @@ fn add_remove_swap_validator() {
         let val_id5 = 5;
         let val_id6 = 6;
 
-        for id in vec![val_id1, val_id2, val_id3, val_id4] {
-            PoAModule::add_validator_(id, false).unwrap();
+        for id in &[val_id1, val_id2, val_id3, val_id4] {
+            PoAModule::add_validator_(*id, false).unwrap();
         }
         PoAModule::update_active_validators_if_needed();
 
@@ -595,8 +596,8 @@ fn txn_fees() {
         let val_id1 = 1;
         let val_id2 = 2;
 
-        for id in vec![val_id1, val_id2] {
-            PoAModule::add_validator_(id, false).unwrap();
+        for id in &[val_id1, val_id2] {
+            PoAModule::add_validator_(*id, false).unwrap();
         }
         PoAModule::update_active_validators_if_needed();
 
@@ -665,8 +666,8 @@ fn epoch_details_and_block_count() {
         let val_id1 = 1;
         let val_id2 = 2;
 
-        for id in vec![val_id1, val_id2] {
-            PoAModule::add_validator_(id, false).unwrap();
+        for id in &[val_id1, val_id2] {
+            PoAModule::add_validator_(*id, false).unwrap();
         }
         PoAModule::update_details_for_ending_epoch(1);
         PoAModule::update_active_validators_if_needed();
@@ -902,8 +903,8 @@ fn validator_block_counts() {
         let val_id1 = 1;
         let val_id2 = 2;
 
-        for id in vec![val_id1, val_id2] {
-            PoAModule::add_validator_(id, false).unwrap();
+        for id in &[val_id1, val_id2] {
+            PoAModule::add_validator_(*id, false).unwrap();
         }
         PoAModule::update_active_validators_if_needed();
         PoAModule::update_details_on_new_epoch(1, 2, 2);
@@ -986,7 +987,7 @@ fn treasury_emission_reward() {
         let mut balance_current = PoAModule::treasury_balance().saturated_into::<u128>();
         assert_eq!(balance_current, 0);
 
-        for (validator_reward, treasury_reward) in vec![
+        for (validator_reward, treasury_reward) in &[
             (100, 60),
             (101, 60),
             (102, 61),
@@ -997,8 +998,8 @@ fn treasury_emission_reward() {
             (10020, 6012),
             (10050, 6030),
         ] {
-            let reward = PoAModule::mint_treasury_emission_rewards(validator_reward);
-            assert_eq!(reward, treasury_reward);
+            let reward = PoAModule::mint_treasury_emission_rewards(*validator_reward);
+            assert_eq!(reward, *treasury_reward);
             let balance_new = PoAModule::treasury_balance().saturated_into::<u128>();
             assert_eq!(balance_new - balance_current, reward);
             balance_current = balance_new;
@@ -1113,8 +1114,8 @@ fn validator_rewards_for_non_empty_epoch() {
 
         let current_epoch_no = 1;
 
-        for id in vec![val_id1, val_id2] {
-            PoAModule::add_validator_(id, false).unwrap();
+        for id in &[val_id1, val_id2] {
+            PoAModule::add_validator_(*id, false).unwrap();
         }
         PoAModule::update_active_validators_if_needed();
         PoAModule::update_details_on_new_epoch(current_epoch_no, 1, 2);
@@ -1129,7 +1130,7 @@ fn validator_rewards_for_non_empty_epoch() {
                 current_epoch_no,
                 expected_slots_per_validator,
                 slots_per_validator,
-                validator_block_counts.clone(),
+                validator_block_counts,
             );
         assert_eq!(total_validator_reward, 0);
         assert_eq!(
@@ -1280,7 +1281,7 @@ fn validator_rewards_for_non_empty_epoch() {
                 current_epoch_no,
                 expected_slots_per_validator,
                 slots_per_validator,
-                validator_block_counts.clone(),
+                validator_block_counts,
             );
         assert_eq!(total_validator_reward, 624);
         // 20% balance remains reserved, rest is free
@@ -1368,7 +1369,7 @@ fn validator_rewards_for_non_empty_epoch() {
                 current_epoch_no,
                 expected_slots_per_validator,
                 slots_per_validator,
-                validator_block_counts.clone(),
+                validator_block_counts,
             );
         assert_eq!(total_validator_reward, 693);
         // 20% balance remains reserved, rest is free
@@ -1419,8 +1420,8 @@ fn rewards_for_non_empty_epoch() {
         let val_id2 = 2;
 
         let current_epoch_no = 1;
-        for id in vec![val_id1, val_id2] {
-            PoAModule::add_validator_(id, false).unwrap();
+        for id in &[val_id1, val_id2] {
+            PoAModule::add_validator_(*id, false).unwrap();
         }
         PoAModule::update_active_validators_if_needed();
         PoAModule::update_details_on_new_epoch(current_epoch_no, 1, 2);
@@ -1498,8 +1499,8 @@ fn emission_rewards_status() {
         let val_id3 = 3;
 
         let current_epoch_no = 1;
-        for id in vec![val_id1, val_id2, val_id3] {
-            PoAModule::add_validator_(id, false).unwrap();
+        for id in &[val_id1, val_id2, val_id3] {
+            PoAModule::add_validator_(*id, false).unwrap();
         }
         PoAModule::update_active_validators_if_needed();
         PoAModule::update_details_on_new_epoch(current_epoch_no, 1, 3);

--- a/pallets/poa/src/tests.rs
+++ b/pallets/poa/src/tests.rs
@@ -1558,23 +1558,38 @@ fn config_set_by_master() {
     new_test_ext().execute_with(|| {
         // Set epoch length
         assert_eq!(PoAModule::min_epoch_length(), 25);
+        assert_eq!(PoAModule::min_epoch_length_tentative(), 0);
         assert_ok!(PoAModule::set_min_epoch_length(RawOrigin::Root.into(), 30));
-        assert_eq!(PoAModule::min_epoch_length(), 30);
-        assert_ok!(PoAModule::set_min_epoch_length(RawOrigin::Root.into(), 25));
+        // Tentative value changed
+        assert_eq!(PoAModule::min_epoch_length_tentative(), 30);
+        // Actual value unchanged
         assert_eq!(PoAModule::min_epoch_length(), 25);
+
+        // Epoch end
+        assert_eq!(PoAModule::get_and_set_min_epoch_length_on_epoch_end(), 30);
+        // Actual value changed
+        assert_eq!(PoAModule::min_epoch_length(), 30);
+        // Tentative value reset
+        assert_eq!(PoAModule::min_epoch_length_tentative(), 0);
 
         // Set max validators
         assert_eq!(PoAModule::max_active_validators(), 4);
+        assert_eq!(PoAModule::max_active_validators_tentative(), 0);
         assert_ok!(PoAModule::set_max_active_validators(
             RawOrigin::Root.into(),
             10
         ));
-        assert_eq!(PoAModule::max_active_validators(), 10);
-        assert_ok!(PoAModule::set_max_active_validators(
-            RawOrigin::Root.into(),
-            4
-        ));
+        // Tentative value changed
+        assert_eq!(PoAModule::max_active_validators_tentative(), 10);
+        // Actual value unchanged
         assert_eq!(PoAModule::max_active_validators(), 4);
+
+        // Epoch end
+        assert_eq!(PoAModule::get_and_set_max_active_validators_on_epoch_end(), 10);
+        // Actual value changed
+        assert_eq!(PoAModule::max_active_validators(), 10);
+        // Tentative value reset
+        assert_eq!(PoAModule::max_active_validators_tentative(), 0);
 
         // Max emission reward per validator
         assert_eq!(PoAModule::max_emm_validator_epoch(), 0);

--- a/pallets/poa/src/tests.rs
+++ b/pallets/poa/src/tests.rs
@@ -1585,7 +1585,10 @@ fn config_set_by_master() {
         assert_eq!(PoAModule::max_active_validators(), 4);
 
         // Epoch end
-        assert_eq!(PoAModule::get_and_set_max_active_validators_on_epoch_end(), 10);
+        assert_eq!(
+            PoAModule::get_and_set_max_active_validators_on_epoch_end(),
+            10
+        );
         // Actual value changed
         assert_eq!(PoAModule::max_active_validators(), 10);
         // Tentative value reset

--- a/pallets/poa/src/tests.rs
+++ b/pallets/poa/src/tests.rs
@@ -188,7 +188,7 @@ fn current_epoch_end() {
             (23, 4, 50),
             (39, 4, 66),
         ] {
-            let epoch_end = PoAModule::set_current_epoch_end(starting_slot, validator_count);
+            let epoch_end = PoAModule::set_next_epoch_end(starting_slot, validator_count);
             assert_eq!(epoch_end, ending_slot);
             assert_eq!(PoAModule::epoch_ends_at(), epoch_end);
         }
@@ -657,36 +657,36 @@ fn epoch_details_and_block_count() {
         }
         PoAModule::update_active_validators_if_needed();
 
-        PoAModule::update_details_on_epoch_change(1, 1, 2);
+        PoAModule::update_details_on_new_epoch(1, 1, 2);
 
         // Epoch details, i.e. `Epoch` and `Epochs` should be updated
         assert_eq!(PoAModule::epoch(), 1);
         assert_eq!(PoAModule::get_epoch_detail(1), (2, 1, None));
 
         // No blocks authored
-        assert_eq!(PoAModule::get_block_count_for_validator(1, &val_id1), 0);
-        assert_eq!(PoAModule::get_block_count_for_validator(1, &val_id2), 0);
+        assert_eq!(PoAModule::get_validator_stats_for_epoch(1, &val_id1), 0);
+        assert_eq!(PoAModule::get_validator_stats_for_epoch(1, &val_id2), 0);
 
         // After val_id1 authors
         PoAModule::increment_current_epoch_block_count(val_id1);
-        assert_eq!(PoAModule::get_block_count_for_validator(1, &val_id1), 1);
-        assert_eq!(PoAModule::get_block_count_for_validator(1, &val_id2), 0);
+        assert_eq!(PoAModule::get_validator_stats_for_epoch(1, &val_id1), 1);
+        assert_eq!(PoAModule::get_validator_stats_for_epoch(1, &val_id2), 0);
 
         // After val_id2 authors
         PoAModule::increment_current_epoch_block_count(val_id2);
-        assert_eq!(PoAModule::get_block_count_for_validator(1, &val_id1), 1);
-        assert_eq!(PoAModule::get_block_count_for_validator(1, &val_id2), 1);
+        assert_eq!(PoAModule::get_validator_stats_for_epoch(1, &val_id1), 1);
+        assert_eq!(PoAModule::get_validator_stats_for_epoch(1, &val_id2), 1);
 
         // They author few more blocks
         PoAModule::increment_current_epoch_block_count(val_id1);
         PoAModule::increment_current_epoch_block_count(val_id2);
         PoAModule::increment_current_epoch_block_count(val_id1);
         PoAModule::increment_current_epoch_block_count(val_id2);
-        assert_eq!(PoAModule::get_block_count_for_validator(1, &val_id1), 3);
-        assert_eq!(PoAModule::get_block_count_for_validator(1, &val_id2), 3);
+        assert_eq!(PoAModule::get_validator_stats_for_epoch(1, &val_id1), 3);
+        assert_eq!(PoAModule::get_validator_stats_for_epoch(1, &val_id2), 3);
 
         // Epoch changes, slot becomes 7
-        PoAModule::update_details_on_epoch_change(2, 7, 2);
+        PoAModule::update_details_on_new_epoch(2, 7, 2);
         // Epoch details, i.e. `Epoch` and `Epochs` should be updated
         assert_eq!(PoAModule::epoch(), 2);
         assert_eq!(PoAModule::get_epoch_detail(2), (2, 7, None));
@@ -698,7 +698,7 @@ fn epoch_details_and_block_count() {
         PoAModule::increment_current_epoch_block_count(val_id2);
         PoAModule::increment_current_epoch_block_count(val_id1);
         PoAModule::increment_current_epoch_block_count(val_id2);
-        assert_eq!(PoAModule::get_block_count_for_validator(2, &val_id1), 2);
-        assert_eq!(PoAModule::get_block_count_for_validator(2, &val_id2), 2);
+        assert_eq!(PoAModule::get_validator_stats_for_epoch(2, &val_id1), 2);
+        assert_eq!(PoAModule::get_validator_stats_for_epoch(2, &val_id2), 2);
     });
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -65,6 +65,7 @@ type Signature = MultiSignature;
 type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::AccountId;
 
 /// Balance of an account.
+// TODO: u64 should be sufficient
 type Balance = u128;
 
 /// Index of a transaction in the chain.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -298,15 +298,8 @@ impl pallet_session::Trait for Runtime {
     type DisabledValidatorsThreshold = ();
 }
 
-parameter_types! {
-    pub const MinEpochLength: u64 = 5;
-    pub const MaxActiveValidators: u8 = 4;
-}
-
 impl poa::Trait for Runtime {
     type Event = Event;
-    type MinEpochLength = MinEpochLength;
-    type MaxActiveValidators = MaxActiveValidators;
     type Currency = balances::Module<Runtime>;
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -308,7 +308,6 @@ parameter_types! {
     pub const UncleGenerations: u32 = 0;
 }
 
-// TODO: Get rid of this and move fee deduction to poa module
 impl pallet_authorship::Trait for Runtime {
     type FindAuthor = pallet_session::FindAccountFromAuthorIndex<Self, Aura>;
     type UncleGenerations = UncleGenerations;


### PR DESCRIPTION
Closes:
https://dock-team.atlassian.net/jira/software/projects/DCK/boards/2?selectedIssue=DCK-228
https://dock-team.atlassian.net/jira/software/projects/DCK/boards/2?selectedIssue=DCK-242
https://dock-team.atlassian.net/jira/software/projects/DCK/boards/2?selectedIssue=DCK-262
https://dock-team.atlassian.net/jira/software/projects/DCK/boards/2?selectedIssue=DCK-264
https://dock-team.atlassian.net/jira/software/projects/DCK/boards/2?selectedIssue=DCK-266

Changes (rough list):

- Count how many blocks are produced by each validator in an epoch, giving them points
- Consider validator points for reward generation and then compute for treasury as well.
- The user logged on to the Master account is able to configure (https://docs.dock.io/learn/governance/gov-poa/poa-1):
  - Epoch duration
  - Validator rewards
  - % of rewards sent to Treasury
  - Maximum allowed validators
  - Lockup ratio for validator emission rewards
- Master can enable or disable emission rewards with a txn anytime to avoid any catastrophy
- After each epoch, the correct amount of rewards are sent to Treasury.
