### PR TITLE
RPC: retrieve registry schemas metadata using `by` argument

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1531,13 +1531,11 @@ dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
  "serde",
- "serde_json",
  "sp-api",
  "sp-blockchain",
  "sp-rpc",
  "sp-runtime",
  "thiserror",
- "utils",
 ]
 
 [[package]]

--- a/pallets/core/Cargo.toml
+++ b/pallets/core/Cargo.toml
@@ -11,6 +11,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies.itertools]
 version = "0.12.1"
 default-features = false
+features = ["use_alloc"]
 
 [dependencies.bitflags]
 version = "1.3.2"

--- a/pallets/core/rpc/src/lib.rs
+++ b/pallets/core/rpc/src/lib.rs
@@ -199,6 +199,14 @@ where
         by: QueryTrustRegistriesBy,
         at: Option<BlockHash>,
     ) -> RpcResult<BTreeMap<TrustRegistryId, TrustRegistryInfo<T::T>>>;
+
+    #[method(name = "trustRegistry_registrySchemaMetadataBy")]
+    async fn registry_schemas_metadata_by(
+        &self,
+        by: QueryTrustRegistryBy,
+        reg_id: TrustRegistryId,
+        at: Option<BlockHash>,
+    ) -> RpcResult<BTreeMap<TrustRegistrySchemaId, AggregatedTrustRegistrySchemaMetadata<T::T>>>;
 }
 
 /// A struct that implements the [`CoreModsApi`].
@@ -567,6 +575,22 @@ where
             // If the block hash is not supplied assume the best block.
             self.client.info().best_hash));
         api.registries_info_by(&at, by)
+            .map_err(Error)
+            .map_err(Into::into)
+    }
+
+    async fn registry_schemas_metadata_by(
+        &self,
+        by: QueryTrustRegistryBy,
+        reg_id: TrustRegistryId,
+        at: Option<<Block as BlockT>::Hash>,
+    ) -> RpcResult<BTreeMap<TrustRegistrySchemaId, AggregatedTrustRegistrySchemaMetadata<T::T>>>
+    {
+        let api = self.client.runtime_api();
+        let at = BlockId::hash(at.unwrap_or_else(||
+            // If the block hash is not supplied assume the best block.
+            self.client.info().best_hash));
+        api.registry_schemas_metadata_by(&at, by, reg_id)
             .map_err(Error)
             .map_err(Into::into)
     }

--- a/pallets/core/src/modules/did/mod.rs
+++ b/pallets/core/src/modules/did/mod.rs
@@ -385,7 +385,8 @@ pub mod pallet {
             _o: OriginFor<T>,
             _s: common::StateChange<'static, T>,
             _d: AggregatedDidDetailsResponse<T>,
-            _i: crate::trust_registry::QueryTrustRegistriesBy,
+            _qi: crate::trust_registry::QueryTrustRegistryBy,
+            _qy: crate::trust_registry::QueryTrustRegistriesBy,
             _a: crate::trust_registry::AggregatedTrustRegistrySchemaMetadata<T>,
         ) -> DispatchResult {
             Err(DispatchError::BadOrigin)

--- a/pallets/core/src/modules/trust_registry/impl.rs
+++ b/pallets/core/src/modules/trust_registry/impl.rs
@@ -1,6 +1,6 @@
+use super::{types::*, *};
 use crate::util::{ActionExecutionError, ApplyUpdate, NonceError, TranslateUpdate, ValidateUpdate};
-
-use super::*;
+use alloc::collections::BTreeSet;
 
 impl<T: Config> Pallet<T> {
     pub(super) fn init_or_update_trust_registry_(
@@ -154,6 +154,35 @@ impl<T: Config> Pallet<T> {
         }
 
         Ok(())
+    }
+
+    pub fn issuer_or_verifier_registries(
+        issuer_or_verifier: IssuerOrVerifier,
+    ) -> BTreeSet<TrustRegistryId> {
+        let issuer_registries = Self::issuer_registries(Issuer(*issuer_or_verifier));
+        let verifier_registries = Self::verifier_registries(Verifier(*issuer_or_verifier));
+
+        issuer_registries
+            .union(&verifier_registries)
+            .copied()
+            .collect()
+    }
+
+    pub fn registry_issuer_or_verifier_schemas(
+        reg_id: TrustRegistryId,
+        issuer_or_verifier: IssuerOrVerifier,
+    ) -> BTreeSet<TrustRegistrySchemaId> {
+        let issuer_schemas = Self::registry_issuer_schemas(reg_id, Issuer(*issuer_or_verifier));
+        let verifier_schemas =
+            Self::registry_verifier_schemas(reg_id, Verifier(*issuer_or_verifier));
+
+        issuer_schemas.union(&verifier_schemas).copied().collect()
+    }
+
+    pub fn aggregate_schema_metadata(
+        (reg_id, schema_id): (TrustRegistryId, TrustRegistrySchemaId),
+    ) -> Option<AggregatedTrustRegistrySchemaMetadata<T>> {
+        TrustRegistrySchemasMetadata::<T>::get(schema_id, reg_id).map(|meta| meta.aggregate(reg_id))
     }
 
     pub fn schema_metadata_by_schema_id(

--- a/pallets/core/src/modules/trust_registry/query.rs
+++ b/pallets/core/src/modules/trust_registry/query.rs
@@ -1,26 +1,137 @@
 use super::*;
-use alloc::collections::BTreeMap;
-use core::borrow::Borrow;
+use alloc::collections::{BTreeMap, BTreeSet};
+use core::{
+    convert::identity,
+    iter::{once, repeat},
+};
+use itertools::Itertools;
 use types::*;
-use codec::EncodeLike;
-use core::iter::Cloned;
 
-/// Specifies arguments to retrieve registry informations by.
-#[derive(Encode, Decode, Clone, Debug, Copy, PartialEq, Eq, Ord, PartialOrd, MaxEncodedLen)]
+/// Specifies arguments to retrieve trust registries informations by.
+#[derive(Encode, Decode, Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[derive(scale_info_derive::TypeInfo)]
 #[scale_info(omit_prefix)]
-pub enum QueryTrustRegistriesBy {
-    Issuer(Issuer),
-    Verifier(Verifier),
-    SchemaId(TrustRegistrySchemaId),
-    IssuerOrVerifier(IssuerOrVerifier),
-    IssuerAndVerifier(IssuerAndVerifier),
-    SchemaIdWithIssuer(TrustRegistrySchemaId, Issuer),
-    SchemaIdWithVerifier(TrustRegistrySchemaId, Verifier),
-    SchemaIdWithIssuerOrVerifier(TrustRegistrySchemaId, IssuerOrVerifier),
-    SchemaIdWithIssuerAndVerifier(TrustRegistrySchemaId, IssuerAndVerifier),
+pub struct QueryTrustRegistriesBy {
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    issuers: Option<AnyOfOrAll<Issuer>>,
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    verifiers: Option<AnyOfOrAll<Verifier>>,
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    issuers_or_verifiers: Option<AnyOfOrAll<IssuerOrVerifier>>,
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    schema_ids: Option<AnyOfOrAll<TrustRegistrySchemaId>>,
+}
+
+/// Specifies arguments to retrieve trust registry informations by.
+#[derive(Encode, Decode, Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[derive(scale_info_derive::TypeInfo)]
+#[scale_info(omit_prefix)]
+pub struct QueryTrustRegistryBy {
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    issuers: Option<AnyOfOrAll<Issuer>>,
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    verifiers: Option<AnyOfOrAll<Verifier>>,
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    issuers_or_verifiers: Option<AnyOfOrAll<IssuerOrVerifier>>,
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    schema_ids: Option<BTreeSet<TrustRegistrySchemaId>>,
+}
+
+#[derive(Encode, Decode, Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[derive(scale_info_derive::TypeInfo)]
+#[scale_info(omit_prefix)]
+pub enum AnyOfOrAll<V: Ord> {
+    AnyOf(BTreeSet<V>),
+    All(BTreeSet<V>),
+}
+
+impl<V: Ord> AnyOfOrAll<V> {
+    pub fn satisfy(&self, others: &BTreeSet<V>) -> bool {
+        match self {
+            Self::AnyOf(values) => !values.is_disjoint(others),
+            Self::All(values) => values.is_subset(others),
+        }
+    }
+
+    pub fn apply<IR, F>(self, f: F) -> BTreeSet<IR::Item>
+    where
+        F: FnMut(V) -> IR,
+        IR: IntoIterator,
+        IR::Item: Ord,
+    {
+        match self {
+            Self::AnyOf(issuers) => issuers.into_iter().flat_map(f).collect(),
+            Self::All(issuers) => {
+                let len = issuers.len();
+
+                issuers
+                    .into_iter()
+                    .map(f)
+                    .kmerge()
+                    .dedup_with_count()
+                    .filter_map(|(count, value)| (count == len).then_some(value))
+                    .collect()
+            }
+        }
+    }
+}
+
+impl QueryTrustRegistryBy {
+    /// Resolves to a map containing `TrustRegistrySchemaId` -> `AggregatedTrustRegistrySchemaMetadata<T>` pairs.
+    pub fn resolve_to_schemas_metadata_in_registry<T: Config>(
+        self,
+        reg_id: TrustRegistryId,
+    ) -> BTreeMap<TrustRegistrySchemaId, AggregatedTrustRegistrySchemaMetadata<T>> {
+        let schema_ids = self.resolve_to_schema_ids_in_registry::<T>(reg_id);
+
+        repeat(reg_id)
+            .zip(schema_ids)
+            .with_schema_metadata()
+            .collect()
+    }
+
+    pub fn resolve_to_schema_ids_in_registry<T: Config>(
+        self,
+        reg_id: TrustRegistryId,
+    ) -> BTreeSet<TrustRegistrySchemaId> {
+        let Self {
+            issuers,
+            verifiers,
+            issuers_or_verifiers,
+            schema_ids,
+        } = self;
+
+        let issuer_schema_ids = issuers.map(|issuers| {
+            issuers.apply(|issuer| Pallet::<T>::registry_issuer_schemas(reg_id, issuer))
+        });
+        let verifier_schema_ids = verifiers.map(|verifiers| {
+            verifiers.apply(|verifier| Pallet::<T>::registry_verifier_schemas(reg_id, verifier))
+        });
+
+        let issuers_and_verifiers_schema_ids =
+            MaybeDoubleSet(issuer_schema_ids, verifier_schema_ids).intersection();
+        let issuers_or_verifiers_schema_ids = issuers_or_verifiers.map(|issuer_or_verifier| {
+            issuer_or_verifier.apply(|issuer_or_verifier| {
+                Pallet::<T>::registry_issuer_or_verifier_schemas(reg_id, issuer_or_verifier)
+            })
+        });
+
+        let combined_issuers_verifiers_schema_ids = MaybeDoubleSet(
+            issuers_and_verifiers_schema_ids,
+            issuers_or_verifiers_schema_ids,
+        )
+        .union();
+
+        MaybeDoubleSet(combined_issuers_verifiers_schema_ids, schema_ids)
+            .intersection()
+            .unwrap_or_default()
+    }
 }
 
 impl QueryTrustRegistriesBy {
@@ -28,80 +139,62 @@ impl QueryTrustRegistriesBy {
     pub fn resolve_to_registries_info<T: Config>(
         self,
     ) -> BTreeMap<TrustRegistryId, TrustRegistryInfo<T>> {
-        match self {
-            Self::Issuer(issuer) => {
-                let IssuerTrustRegistries(registries) = Pallet::<T>::issuer_registries(issuer);
+        self.resolve_to_registry_ids::<T>()
+            .with_registry_info()
+            .collect()
+    }
 
-                registries.with_registry_info().collect()
-            }
-            Self::Verifier(verifier) => {
-                let VerifierTrustRegistries(registries) =
-                    Pallet::<T>::verifier_registries(verifier);
+    pub fn resolve_to_registry_ids<T: Config>(self) -> BTreeSet<TrustRegistryId> {
+        let Self {
+            issuers,
+            verifiers,
+            issuers_or_verifiers,
+            schema_ids,
+        } = self;
 
-                registries.with_registry_info().collect()
-            }
-            Self::SchemaId(schema_id) => {
-                TrustRegistrySchemasMetadata::<T>::iter_key_prefix(schema_id)
-                    .with_registry_info()
-                    .collect()
-            }
-            Self::IssuerOrVerifier(issuer_or_verifier) => {
-                let issuer_regs = Pallet::<T>::issuer_registries(Issuer(*issuer_or_verifier));
-                let verifier_regs = Pallet::<T>::verifier_registries(Verifier(*issuer_or_verifier));
+        let issuer_regs = issuers.map(|issuers| issuers.apply(Pallet::<T>::issuer_registries));
+        let verifier_regs =
+            verifiers.map(|verifiers| verifiers.apply(Pallet::<T>::verifier_registries));
 
-                issuer_regs
-                    .union(&verifier_regs)
-                    .copied()
-                    .with_registry_info()
-                    .collect()
-            }
-            Self::IssuerAndVerifier(issuer_and_verifier) => {
-                let issuer_regs = Pallet::<T>::issuer_registries(Issuer(*issuer_and_verifier));
-                let verifier_regs =
-                    Pallet::<T>::verifier_registries(Verifier(*issuer_and_verifier));
+        let issuers_and_verifiers_regs = MaybeDoubleSet(issuer_regs, verifier_regs).intersection();
+        let issuers_or_verifiers_regs = issuers_or_verifiers.map(|issuers_or_verifiers| {
+            issuers_or_verifiers.apply(Pallet::<T>::issuer_or_verifier_registries)
+        });
 
-                issuer_regs
-                    .intersection(&verifier_regs)
-                    .copied()
-                    .with_registry_info()
-                    .collect()
-            }
-            Self::SchemaIdWithIssuer(schema_id, issuer) => {
-                let issuer_registries = Pallet::<T>::issuer_registries(issuer);
+        let combined_issuers_verifiers_regs =
+            MaybeDoubleSet(issuers_or_verifiers_regs, issuers_and_verifiers_regs).intersection();
+        let schema_id_regs = schema_ids
+            .map(|schema_ids| schema_ids.apply(TrustRegistrySchemasMetadata::<T>::iter_key_prefix));
 
-                TrustRegistrySchemasMetadata::<T>::iter_key_prefix(schema_id)
-                    .filter(|reg_id| issuer_registries.contains(reg_id))
-                    .with_registry_info()
-                    .collect()
-            }
-            Self::SchemaIdWithVerifier(schema_id, verifier) => {
-                let verifier_registries = Pallet::<T>::verifier_registries(verifier);
+        MaybeDoubleSet(combined_issuers_verifiers_regs, schema_id_regs)
+            .intersection()
+            .unwrap_or_default()
+    }
+}
 
-                TrustRegistrySchemasMetadata::<T>::iter_key_prefix(schema_id)
-                    .filter(|reg_id| verifier_registries.contains(reg_id))
-                    .with_registry_info()
-                    .collect()
-            }
-            Self::SchemaIdWithIssuerOrVerifier(schema_id, issuer_or_verifier) => {
-                let issuer_regs = Pallet::<T>::issuer_registries(Issuer(*issuer_or_verifier));
-                let verifier_regs = Pallet::<T>::verifier_registries(Verifier(*issuer_or_verifier));
+struct MaybeDoubleSet<V: Ord>(Option<BTreeSet<V>>, Option<BTreeSet<V>>);
 
-                TrustRegistrySchemasMetadata::<T>::iter_key_prefix(schema_id)
-                    .filter(|reg_id| issuer_regs.contains(reg_id) || verifier_regs.contains(reg_id))
-                    .with_registry_info()
-                    .collect()
-            }
-            Self::SchemaIdWithIssuerAndVerifier(schema_id, issuer_and_verifier) => {
-                let issuer_regs = Pallet::<T>::issuer_registries(Issuer(*issuer_and_verifier));
-                let verifier_regs =
-                    Pallet::<T>::verifier_registries(Verifier(*issuer_and_verifier));
+impl<V: Ord + Clone> MaybeDoubleSet<V> {
+    fn intersection(self) -> Option<BTreeSet<V>> {
+        let Self(first, second) = self;
 
-                TrustRegistrySchemasMetadata::<T>::iter_key_prefix(schema_id)
-                    .filter(|reg_id| issuer_regs.contains(reg_id) && verifier_regs.contains(reg_id))
-                    .with_registry_info()
-                    .collect()
-            }
-        }
+        Some(match (first, second) {
+            (Some(first), Some(second)) => first.intersection(&second).cloned().collect(),
+            (Some(first), None) => first,
+            (None, Some(second)) => second,
+            (None, None) => None?,
+        })
+    }
+
+    fn union(self) -> Option<BTreeSet<V>> {
+        let Self(first, second) = self;
+
+        Some(match (first, second) {
+            (Some(first), Some(second)) => first.union(&second).cloned().collect(),
+            (Some(first), None) => first,
+            (None, Some(second)) => second,
+            (None, None) => None?,
+        })
     }
 }
 
@@ -109,9 +202,20 @@ impl QueryTrustRegistriesBy {
 trait IntoIterExt: IntoIterator + Sized {
     /// Transforms value to an iterator emitting `TrustRegistryId`, then transforms result to an iterator producing
     /// `(TrustRegistryId, TrustRegistryInfo<T>)` pairs.
-    fn with_registry_info<T>(self) -> WithEntity<Self::IntoIter, TrustRegistryInfo<T>>
+    fn with_registry_info<T>(
+        self,
+    ) -> WithEntity<Self::IntoIter, TrustRegistryId, TrustRegistryInfo<T>>
     where
-        Self::Item: Clone + EncodeLike<TrustRegistryId>,
+        Self: IntoIterator<Item = TrustRegistryId>,
+        T: Config;
+
+    /// Transforms value to an iterator emitting `(TrustRegistryId, TrustRegistrySchemaId)`, then transforms result to an iterator producing
+    /// `(TrustRegistrySchemaId, AggregatedTrustRegistrySchemaMetadata<T>)` pairs.
+    fn with_schema_metadata<T>(
+        self,
+    ) -> WithEntity<Self::IntoIter, TrustRegistrySchemaId, AggregatedTrustRegistrySchemaMetadata<T>>
+    where
+        Self: IntoIterator<Item = (TrustRegistryId, TrustRegistrySchemaId)>,
         T: Config;
 }
 
@@ -119,44 +223,65 @@ impl<I> IntoIterExt for I
 where
     I: IntoIterator,
 {
-    fn with_registry_info<T>(self) -> WithEntity<Self::IntoIter, TrustRegistryInfo<T>>
+    fn with_registry_info<T>(
+        self,
+    ) -> WithEntity<Self::IntoIter, TrustRegistryId, TrustRegistryInfo<T>>
     where
-        Self::Item: Clone + EncodeLike<TrustRegistryId>,
+        Self: IntoIterator<Item = TrustRegistryId>,
         T: Config,
     {
-        WithEntity::new(self.into_iter(), TrustRegistriesInfo::<T>::get as _)
+        WithEntity::new(
+            self.into_iter(),
+            identity,
+            TrustRegistriesInfo::<T>::get as _,
+        )
+    }
+
+    fn with_schema_metadata<T>(
+        self,
+    ) -> WithEntity<Self::IntoIter, TrustRegistrySchemaId, AggregatedTrustRegistrySchemaMetadata<T>>
+    where
+        Self: IntoIterator<Item = (TrustRegistryId, TrustRegistrySchemaId)>,
+        T: Config,
+    {
+        WithEntity::new(
+            self.into_iter(),
+            take_second::<TrustRegistryId, TrustRegistrySchemaId>,
+            Pallet::<T>::aggregate_schema_metadata as _,
+        )
     }
 }
 
-/// A wrapper for the iterator that converts an iterator of `TrustRegistryId`
-/// to an iterator of `(TrustRegistryId, TrustRegistryInfo<T>)`.
-pub struct WithEntity<I: Iterator, E>(I, fn(I::Item) -> Option<E>);
-
-trait GetStorageValue<Key> {
-    type Value;
-
-    fn get(key: Key) -> Self::Value;
+fn take_second<A, B>((_first, second): (A, B)) -> B {
+    second
 }
 
-impl<I, E> WithEntity<I, E> where I: Iterator {
-    fn new(iter: I, f: fn(I::Item) -> Option<E>) -> Self {
-        Self(iter, f)
+/// A wrapper for the iterator that converts an iterator of identifiers
+/// to an iterator of paired identifiers and the corresponding entities.
+pub struct WithEntity<I: Iterator, K, V>(I, fn(I::Item) -> K, fn(I::Item) -> Option<V>);
+
+impl<I, K, V> WithEntity<I, K, V>
+where
+    I: Iterator,
+{
+    fn new(iter: I, map_key: fn(I::Item) -> K, map_value: fn(I::Item) -> Option<V>) -> Self {
+        Self(iter, map_key, map_value)
     }
 }
 
-impl<I, E> Iterator for WithEntity<I, E>
+impl<I, K, V> Iterator for WithEntity<I, K, V>
 where
     I: Iterator,
     I::Item: Clone,
 {
-    type Item = (I::Item, E);
+    type Item = (K, V);
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             let id = self.0.next()?;
 
-            if let Some(data) = self.1(id.clone()) {
-                break Some((id, data));
+            if let Some(data) = self.2(id.clone()) {
+                break Some((self.1(id), data));
             }
         }
     }

--- a/pallets/core/src/modules/trust_registry/types.rs
+++ b/pallets/core/src/modules/trust_registry/types.rs
@@ -608,6 +608,15 @@ pub struct VerifierSchemas<T: Limits>(
 
 impl_wrapper!(VerifierSchemas<T> where T: Limits => (BoundedBTreeSet<TrustRegistrySchemaId, T::MaxSchemasPerVerifier>));
 
+impl<T: Limits> IntoIterator for VerifierSchemas<T> {
+    type IntoIter = alloc::collections::btree_set::IntoIter<TrustRegistrySchemaId>;
+    type Item = TrustRegistrySchemaId;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
 /// Set of trust registries corresponding to a verifier
 #[derive(
     Encode,
@@ -633,6 +642,15 @@ pub struct VerifierTrustRegistries<T: Limits>(
 );
 
 impl_wrapper!(VerifierTrustRegistries<T> where T: Limits => (BoundedBTreeSet<TrustRegistryId, T::MaxRegistriesPerVerifier>));
+
+impl<T: Limits> IntoIterator for VerifierTrustRegistries<T> {
+    type IntoIter = alloc::collections::btree_set::IntoIter<TrustRegistryId>;
+    type Item = TrustRegistryId;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
 
 /// Set of schemas that belong to the `Trust Registry`
 #[derive(
@@ -686,6 +704,15 @@ pub struct IssuerSchemas<T: Limits>(
 
 impl_wrapper!(IssuerSchemas<T> where T: Limits => (BoundedBTreeSet<TrustRegistrySchemaId, T::MaxSchemasPerIssuer>));
 
+impl<T: Limits> IntoIterator for IssuerSchemas<T> {
+    type IntoIter = alloc::collections::btree_set::IntoIter<TrustRegistrySchemaId>;
+    type Item = TrustRegistrySchemaId;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
 /// Set of trust registries corresponding to a issuer
 #[derive(
     Encode,
@@ -711,6 +738,15 @@ pub struct IssuerTrustRegistries<T: Limits>(
 );
 
 impl_wrapper!(IssuerTrustRegistries<T> where T: Limits => (BoundedBTreeSet<TrustRegistryId, T::MaxRegistriesPerIssuer>));
+
+impl<T: Limits> IntoIterator for IssuerTrustRegistries<T> {
+    type IntoIter = alloc::collections::btree_set::IntoIter<TrustRegistryId>;
+    type Item = TrustRegistryId;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
 
 #[derive(
     Encode,

--- a/pallets/core/src/runtime_api.rs
+++ b/pallets/core/src/runtime_api.rs
@@ -73,5 +73,10 @@ sp_api::decl_runtime_apis! {
         fn registries_info_by(
             by: QueryTrustRegistriesBy
         ) -> BTreeMap<TrustRegistryId, TrustRegistryInfo<T>>;
+
+        fn registry_schemas_metadata_by(
+            by: QueryTrustRegistryBy,
+            reg_id: TrustRegistryId
+        ) -> BTreeMap<TrustRegistrySchemaId, AggregatedTrustRegistrySchemaMetadata<T>>;
     }
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -2544,6 +2544,13 @@ impl_runtime_apis! {
         ) -> BTreeMap<trust_registry::TrustRegistryId, trust_registry::TrustRegistryInfo<Runtime>> {
             by.resolve_to_registries_info()
         }
+
+        fn registry_schemas_metadata_by(
+            by: trust_registry::QueryTrustRegistryBy,
+            reg_id: trust_registry::TrustRegistryId
+        ) -> BTreeMap<trust_registry::TrustRegistrySchemaId, trust_registry::AggregatedTrustRegistrySchemaMetadata<Runtime>> {
+            by.resolve_to_schemas_metadata_in_registry(reg_id)
+        }
     }
 
     #[cfg(feature = "runtime-benchmarks")]


### PR DESCRIPTION
Add RPC call to retrieve all matching registry schemas using the `by` argument.